### PR TITLE
Обновление mik32.cfg

### DIFF
--- a/openocd-scripts/target/mik32.cfg
+++ b/openocd-scripts/target/mik32.cfg
@@ -8,14 +8,17 @@ proc init_targets {} {
 
   set _CHIPNAME riscv
   set _CPUTAPID 0xdeb11001
+  set _SYSTAPID 0xfffffffe
 
   jtag newtap $_CHIPNAME cpu -irlen 5 -ircapture 0x1 -irmask 0x1f -expected-id $_CPUTAPID
 
-  jtag newtap $_CHIPNAME sys -irlen 4 -ircapture 0x05 -irmask 0x0F -enable
+  jtag newtap $_CHIPNAME sys -irlen 4 -ircapture 0x05 -irmask 0x0F -enable -expected-id $_SYSTAPID -ignore-bypass
     
   set _TARGETNAME $_CHIPNAME.cpu
 
   target create $_TARGETNAME riscv -endian little -chain-position $_TARGETNAME -coreid 0
+
+  riscv expose_csrs 2016=mcounten
 
   riscv.cpu configure -event reset-init my_init_proc
 }


### PR DESCRIPTION
1) Сокращение вывода бесполезных предупреждений;
2) Добавление нестандартного CSR-регистра MCOUNTEN, используемого для управления активностью счётчиков производительности (тактов и команд).